### PR TITLE
New Apple Intermediate Certificate

### DIFF
--- a/vendor/mdm_vendor_sign.py
+++ b/vendor/mdm_vendor_sign.py
@@ -1,6 +1,5 @@
 # This is based loosely on Softthinker's java code found here
 # http://www.softhinker.com/in-the-news/iosmdmvendorcsrsigning
-# fuck java
 
 import argparse
 from plistlib import writePlistToString
@@ -125,7 +124,7 @@ openssl rsa -in key.pem -out the_private_key.key
 	# TODO : Probably should verify these too
 
 	p('Downloading WWDR intermediate certificate...')
-	intermediate_cer = urllib2.urlopen('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer').read()
+	intermediate_cer = urllib2.urlopen('https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer').read()
 	p(' converting to pem...')
 	intermediate_pem = cer_to_pem(intermediate_cer)
 	p('OK\n')


### PR DESCRIPTION
* Update to account for change in Apple intermediate certificate. This is the new default for all Apple certificates being generated.